### PR TITLE
CDRIVER-4172 output performance results in new perf.send format

### DIFF
--- a/src/mongo-c-performance.c
+++ b/src/mongo-c-performance.c
@@ -298,8 +298,7 @@ void
 print_header (void)
 {
    fprintf (output,
-            "{\n"
-            "  \"results\": [\n");
+            "[\n");
 
    is_first_test = true;
 }
@@ -315,14 +314,17 @@ print_result (const char *name, double ops_per_sec)
    is_first_test = false;
 
    fprintf (output,
-            "    {\n"
-            "      \"name\": \"%s\",\n"
-            "      \"results\": {\n"
-            "        \"1\": {\n"
-            "          \"ops_per_sec\": %f\n"
-            "        }\n"
+            "  {\n"
+            "    \"info\": {\n"
+            "      \"test_name\": \"%s\"\n"
+            "    },\n"
+            "    \"metrics\": [\n"
+            "      {\n"
+            "        \"name\": \"ops_per_sec\",\n"
+            "        \"value\": %f\n"
             "      }\n"
-            "    }",
+            "    ]\n"
+            "  }",
             name,
             ops_per_sec);
 }
@@ -333,8 +335,7 @@ print_footer (void)
 {
    fprintf (output,
             "\n"
-            "  ]\n"
-            "}\n");
+            "]\n");
 }
 
 


### PR DESCRIPTION
Patch build that incorporates these changes via a patch in the C driver build: https://spruce.mongodb.com/version/617e1b02d6d80a6eb492398f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC