### PR TITLE
Fix build for 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cmake_install.cmake
 Makefile
 mongo-c-performance.cbp
 cmake-build-*
+cmake-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,11 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.15)
 project(mongo-c-performance)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/build/cmake/")
 
 find_package (Threads)
 
-set(LIBMONGOC_REQUIRED_VERSION 1.9.2)
-find_package(mongoc-1.0 ${LIBMONGOC_REQUIRED_VERSION} REQUIRED)
+find_package(mongoc 2.0 REQUIRED)
 
 include_directories(
     ${MONGOC_INCLUDE_DIRS}
@@ -29,6 +28,6 @@ set(SOURCE_FILES
 add_executable(mongo-c-performance ${SOURCE_FILES})
 target_link_libraries(
         mongo-c-performance
-        mongo::mongoc_shared
+        mongoc::shared
         ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/src/ldjson-performance.c
+++ b/src/ldjson-performance.c
@@ -441,7 +441,7 @@ _export_thread (void *p)
 #endif
    total_sz = 0;
    while (mongoc_cursor_next (cursor, &doc)) {
-      json = bson_as_json (doc, &sz);
+      json = bson_as_legacy_extended_json (doc, &sz);
       if (fwrite (json, sizeof (char), sz, fp) < sz) {
          perror ("fwrite");
          abort ();


### PR DESCRIPTION
Fix failing builds related to C driver 2.0 breaking changes.

Tested with this patch build: https://spruce.mongodb.com/version/68126d57fead0f0007f1278d

I added an e-mail alert to the [mongo-c-driver-perf Evergreen project](https://spruce.mongodb.com/project/mongo-c-driver-perf/settings/notifications) to match the [mongo-c-driver Evergreen project](https://spruce.mongodb.com/project/mongo-c-driver/settings/notifications) to notify of a build break.